### PR TITLE
add new variable for searchui version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ SEARCH_UI_VERSION accepts a specific version such as '2.10107.0', or a tag such 
 Browse to this page on the Netlify console (requires log-in):
 https://app.netlify.com/sites/coveo-test-search/settings/env
 
-Set a specific version here as a string, such as '2.10107.0', or a tag, such as 'latest'
+Set a specific version here as a string, such as '2.10107.0', or a tag, such as 'latest'.
+
+Remember to set it back to an empty value or 'beta' when you're done testing the version.
 
 ### Forcing a specific version locally on Mac/Linux
 

--- a/README.md
+++ b/README.md
@@ -23,3 +23,32 @@ tracked by git. They may be overwritten next time you run the server.
 
 If you make changes to files in `./testpages`, these changes will be tracked 
 by git. In order to see the changes locally, you can re-run `npm start`.
+
+## Building a search-ui version other than 'beta'
+
+The gulpfile looks for the environment variable SEARCH_UI_VERSION. If it doesn't find one,
+it defaults to building the version with the 'beta' tag.
+
+See here for versions:
+https://www.npmjs.com/package/coveo-search-ui?activeTab=versions
+
+SEARCH_UI_VERSION accepts a specific version such as '2.10107.0', or a tag such as 'latest'
+
+### Setting the value in the Netlify build
+
+Browse to this page on the Netlify console (requires log-in):
+https://app.netlify.com/sites/coveo-test-search/settings/env
+
+Set a specific version here as a string, such as '2.10107.0', or a tag, such as 'latest'
+
+### Forcing a specific version locally on Mac/Linux
+
+```sh
+NPM_VERSION_TO_BUILD=2.10106.1 npm i
+```
+
+### Forcing a specific version locally on Windows
+
+```bat
+cmd /C "set NPM_VERSION_TO_BUILD=2.10106.1 && npm i"
+```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ Run local server with:
 
 The server will be accessible at http://localhost:5001/
 
+## Building on Netlify
+
+If you have no changes to make to the test files, just run the build hook using the value stored in Lastpass:
+```
+curl --request POST 'https://api.netlify.com/build_hooks/63891a2e11339b52ac8e9e2a'
+```
+This will build the beta version by default, or whatever version is set as the environment variable
+SEARCH_UI_VERSION in Netlify (See `Building a search-ui version other than 'beta'` below).
+
+If you need to change anything in the repo, Netlify will build when you merge your PR.
 
 ## Changing test files
 
@@ -47,11 +57,11 @@ Remember to set it back to an empty value or 'beta' when you're done testing the
 ### Forcing a specific version locally on Mac/Linux
 
 ```sh
-NPM_VERSION_TO_BUILD=2.10106.1 npm i
+SEARCH_UI_VERSION=2.10106.1 npm i
 ```
 
 ### Forcing a specific version locally on Windows
 
 ```bat
-cmd /C "set NPM_VERSION_TO_BUILD=2.10106.1 && npm i"
+cmd /C "set SEARCH_UI_VERSION=2.10106.1 && npm i"
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ by git. In order to see the changes locally, you can re-run `npm start`.
 ## Building a search-ui version other than 'beta'
 
 The gulpfile looks for the environment variable SEARCH_UI_VERSION. If it doesn't find one,
-it defaults to building the version with the 'beta' tag.
+it defaults to building the version with the 'beta' tag. This overrides any value you put 
+in `coveo-search-ui` value you set in the `package.json` dependencies.
 
 See here for versions:
 https://www.npmjs.com/package/coveo-search-ui?activeTab=versions

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The server will be accessible at http://localhost:5001/
 
 If you have no changes to make to the test files, just run the build hook using the value stored in Lastpass:
 ```
-curl --request POST 'https://api.netlify.com/build_hooks/63891a2e11339b52ac8e9e2a'
+curl --request POST 'https://api.netlify.com/build_hooks/************************'
 ```
 This will build the beta version by default, or whatever version is set as the environment variable
 SEARCH_UI_VERSION in Netlify (See `Building a search-ui version other than 'beta'` below).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,8 +2,12 @@ const gulp = require("gulp");
 const debug = require("gulp-debug");
 const exec = require("child_process").exec;
 
-gulp.task("installBetaPackage", function (cb) {
-  return exec("npm i coveo-search-ui@beta", function (err, stdout, stderr) {
+// This value can be set in Netlify to force a version other than 'beta'. see README.md
+const searchUiVersion = process.env.SEARCH_UI_VERSION;;
+
+gulp.task("installPackage", function (cb) {
+  const version = searchUiVersion || 'beta'
+  return exec("npm i coveo-search-ui@" + version, function (err, stdout, stderr) {
     console.log(stdout);
     console.log(stderr);
     cb(err);
@@ -34,7 +38,7 @@ gulp.task("copySearchUi", function () {
 gulp.task(
   "default",
   gulp.series(
-    "installBetaPackage",
+    "installPackage",
     "copyCustomUi",
     "copySearchUi",
     async function () {}


### PR DESCRIPTION
Have a look at the README.md. I think this is the best approach for setting any JSUI version to be built

In Netlify: https://app.netlify.com/sites/coveo-test-search/settings/env
<img width="1554" alt="Screen Shot 2023-03-06 at 5 43 23 PM" src="https://user-images.githubusercontent.com/75636363/223270107-3302a247-9290-47a0-a33e-649f982857be.png">

